### PR TITLE
Add timezone configuration

### DIFF
--- a/include/config.inc.php
+++ b/include/config.inc.php
@@ -37,4 +37,5 @@ $_config['enable_logging']=false;
 // log file, should not be publicly viewable
 $_config['log_file']="/var/log/aro.log";
 
-?>
+// Default timezone to be set
+$_config['timezone'] = 'UTC';

--- a/include/init.inc.php
+++ b/include/init.inc.php
@@ -1,8 +1,6 @@
 <?php
 // ARO version
 define("VERSION", "0.3.0");
-// Amsterdam timezone by default, should probably be moved to config
-date_default_timezone_set("Europe/Amsterdam");
 
 
 
@@ -17,6 +15,10 @@ if(php_sapi_name() !== 'cli'&&substr_count($_SERVER['PHP_SELF'],"/")>1){
 
 
 require_once("include/config.inc.php");
+
+// Set default timezone from configuration
+date_default_timezone_set($_config['timezone']);
+
 require_once("include/db.inc.php");
 require_once("include/functions.inc.php");
 require_once("include/block.inc.php");

--- a/include/init.inc.php
+++ b/include/init.inc.php
@@ -17,7 +17,7 @@ if(php_sapi_name() !== 'cli'&&substr_count($_SERVER['PHP_SELF'],"/")>1){
 require_once("include/config.inc.php");
 
 // Set default timezone from configuration
-date_default_timezone_set($_config['timezone']);
+date_default_timezone_set($_config['timezone'] ?? 'UTC');
 
 require_once("include/db.inc.php");
 require_once("include/functions.inc.php");


### PR DESCRIPTION
This change adds a new configuration parameter called 'timezone' for setting the node's timezone.

If not set, it will fallback to UTC (which is also the default).

Closes #9