### PR TITLE
Beautify the sample configuration with sections

### DIFF
--- a/include/config-sample.inc.php
+++ b/include/config-sample.inc.php
@@ -1,44 +1,111 @@
 <?php
-// Database connection
-$_config['db_connect']="mysql:host=localhost;dbname=ENTER-DB-NAME";
-$_config['db_user']="ENTER-DB-USER";
-$_config['db_pass']="ENTER-DB-PASS";
+
+/*
+|--------------------------------------------------------------------------
+| Database Configuration
+|--------------------------------------------------------------------------
+*/
+
+// The database DSN
+$_config['db_connect'] = 'mysql:host=localhost;dbname=ENTER-DB-NAME';
+
+// The database username
+$_config['db_user'] = 'ENTER-DB-USER';
+
+// The database password
+$_config['db_pass'] = 'ENTER-DB-PASS';
+
+/*
+|--------------------------------------------------------------------------
+| General Configuration
+|--------------------------------------------------------------------------
+*/
 
 // Maximum number of connected peers
-$_config['max_peers']=30;
-// Testnet, used for development
-$_config['testnet']=false;
+$_config['max_peers'] = 30;
+
+// Enable testnet mode for development
+$_config['testnet'] = false;
+
 // To avoid any problems if other clones are made
-$_config['coin']="arionum";
-// maximum transactions accepted from a single peer
-$_config['peer_max_mempool']=100;
-// maximum mempool transactions to be rebroadcasted
-$_config['max_mempool_rebroadcast']=5000;
-// after how many blocks should the transactions be rebroadcasted
-$_config['sanity_rebroadcast_height']=30;
-// each new received transaction is sent to X peers
-$_config['transaction_propagation_peers']=5;
-// how many new peers to check from each peer.
-$_config['max_test_peers']=5;
-// recheck the last blocks on sanity
-$_config['sanity_recheck_blocks']=10;
-// allow others to connect to node api. If set to false, only allowed_hosts are allowed
-$_config['public_api']=true;
-// hosts allowed to mine on this node
-$_config['allowed_hosts']=array("127.0.0.1");
-// sanity is run every X seconds
-$_config['sanity_interval']=900;
-// accept the setting of new hostnames / should be used only if you want to change the hostname
-$_config['allow_hostname_change']=false;
-// rebroadcast local transactions on each sanity
-$_config['sanity_rebroadcast_locals']=true;
-// write logs to file
-$_config['enable_logging']=false;
-// log file, should not be publicly viewable
-$_config['log_file']="/var/log/aro.log";
-//log verbosity, default 0, maximum 3
-$_config['log_verbosity']=0;
-//will this run as a masternode?
-$_config['masternode']=false;
-//masternode public key
-$_config['masternode_public_key']="";
+$_config['coin'] = 'arionum';
+
+// Allow others to connect to the node api (if set to false, only the below 'allowed_hosts' are allowed)
+$_config['public_api'] = true;
+
+// Hosts that are allowed to mine on this node
+$_config['allowed_hosts'] = [
+    '127.0.0.1',
+];
+
+/*
+|--------------------------------------------------------------------------
+| Peer Configuration
+|--------------------------------------------------------------------------
+*/
+
+// The number of peers to send each new transaction to
+$_config['transaction_propagation_peers'] = 5;
+
+// How many new peers to check from each peer
+$_config['max_test_peers'] = 5;
+
+/*
+|--------------------------------------------------------------------------
+| Mempool Configuration
+|--------------------------------------------------------------------------
+*/
+
+// The maximum transactions to accept from a single peer
+$_config['peer_max_mempool'] = 100;
+
+// The maximum number of mempool transactions to be rebroadcasted
+$_config['max_mempool_rebroadcast'] = 5000;
+
+// The number of blocks between rebroadcasting transactions
+$_config['sanity_rebroadcast_height'] = 30;
+
+/*
+|--------------------------------------------------------------------------
+| Sanity Configuration
+|--------------------------------------------------------------------------
+*/
+
+// Recheck the last blocks on sanity
+$_config['sanity_recheck_blocks'] = 10;
+
+// The interval to run the sanity in seconds
+$_config['sanity_interval'] = 900;
+
+// Enable setting a new hostname (should be used only if you want to change the hostname)
+$_config['allow_hostname_change'] = false;
+
+// Rebroadcast local transactions when running sanity
+$_config['sanity_rebroadcast_locals'] = true;
+
+/*
+|--------------------------------------------------------------------------
+| Logging Configuration
+|--------------------------------------------------------------------------
+*/
+
+// Enable log output to the specified file
+$_config['enable_logging'] = false;
+
+// The specified file to write to (this should not be publicly visible)
+$_config['log_file'] = '/var/log/aro.log';
+
+// Log verbosity (default 0, maximum 3)
+$_config['log_verbosity'] = 0;
+
+/*
+|--------------------------------------------------------------------------
+| Masternode Configuration
+|--------------------------------------------------------------------------
+*/
+
+// Enable this node as a masternode
+$_config['masternode'] = false;
+
+// The public key for the masternode
+$_config['masternode_public_key'] = '';


### PR DESCRIPTION
As we've renamed the `config.inc.php` to `config-sample.inc.php` as part of #15, I thought it may be good to beautify the configuration at the same time.

This way, anyone updating their node won't be affected by the change. But it is a bit more readable for future versions.

This change splits the configuration into the following sections:
- Database
- General
- Peer
- Mempool
- Sanity
- Logging
- Masternode

I wasn't sure if `General` should be before `Database`, but I left it as is because the database details are the main things that need to be changed when installing a new node.