### PR TITLE
Add a configuration file for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
   - travis_retry composer update --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpcs -p --standard=psr2 . include
+  - vendor/bin/phpcs -p -l --standard=psr2 . include

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_script:
   - travis_retry composer update --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpcs -p -l --standard=psr2 . include
+  - vendor/bin/phpcs -l --standard=psr2 . include

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+dist: trusty
+language: php
+
+php:
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+# This triggers builds to run on the new TravisCI infrastructure.
+# See: https://docs.travis-ci.com/user/reference/trusty#Container-based-with-sudo%3A-false
+sudo: false
+
+## Cache composer
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+before_script:
+  - travis_retry composer update --no-interaction --prefer-dist
+
+script:
+  - vendor/bin/phpcs -p --standard=psr2 . include


### PR DESCRIPTION
Currently there is nothing in the repository to keep people consistently using the PSR-2 code style, or to run unit tests, etc.

Therefore I propose using some form of continuous integration service. I've used Travis CI for years, and it's free for open source so I feel like it's worth using. It also has great integration with the GitHub '[Checks API](https://developer.github.com/v3/checks)' feature.

For an example of the Checks integration see here:
https://github.com/pxgamer/arionum-node/runs/14472263

----

Currently this Travis config just:
- Runs on PHP 7.2 and `nightly` builds
- Installs the Composer dev dependencies (currently just PHP_CodeSniffer)
- Checks for PSR-2 code styling for the current (`.`) and the `include` directory

Here's an example of the Travis build log for PHP 7.2:
https://travis-ci.com/pxgamer/arionum-node/jobs/142523773

----

Although there isn't much in this, in future it would be good to add PHPUnit (or other) for unit testing the codebase, or perhaps running specific commands on tagged releases.

Feel free to look over this PR to see how it works, or check out the [Travis CI documentation](https://docs.travis-ci.com) to find out more. Alternatively, to set up the integration with GitHub, check out the [GitHub Marketplace](https://github.com/marketplace/travis-ci) listing for Travis CI.