### PR TITLE
Add JSON header setting to the api functions

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -24,6 +24,10 @@ function san_host($a)
 function api_err($data)
 {
     global $_config;
+
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
     echo json_encode(["status" => "error", "data" => $data, "coin" => $_config['coin']]);
     exit;
 }
@@ -32,6 +36,10 @@ function api_err($data)
 function api_echo($data)
 {
     global $_config;
+
+    if (!headers_sent()) {
+        header('Content-Type: application/json');
+    }
     echo json_encode(["status" => "ok", "data" => $data, "coin" => $_config['coin']]);
     exit;
 }


### PR DESCRIPTION
This checks if the headers have already been sent, and if not it uses the `application/json` mimetype. This is recommended for APIs and allows browsers (and other programs) to detect that it is JSON being returned.