### PR TITLE
Add initial peers list to configuration

### DIFF
--- a/include/Exception.php
+++ b/include/Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Arionum;
+
+/**
+ * Class Exception
+ * A custom exception for Arionum error handling.
+ */
+class Exception extends \Exception
+{
+}

--- a/include/Exception.php
+++ b/include/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Arionum;
+namespace Arionum\Node;
 
 /**
  * Class Exception

--- a/include/InitialPeers.php
+++ b/include/InitialPeers.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Arionum;
+
+/**
+ * Class InitialPeers
+ */
+final class InitialPeers
+{
+    public const MINIMUM_PEERS_REQUIRED = 2;
+    public const PRELOAD_ERROR = 'Unable to retrieve peers from the preload list.';
+    public const PRELOAD_LIST = 'https://www.arionum.com/peers.txt';
+
+    /**
+     * @var array
+     */
+    private $peerList = [];
+
+    /**
+     * InitialPeers constructor.
+     * @param array|null $peerList
+     * @return void
+     */
+    public function __construct(?array $peerList = [])
+    {
+        $this->peerList = $peerList;
+    }
+
+    /**
+     * Retrieve a peer from the initial peer list.
+     * @return string
+     * @throws Exception
+     */
+    public function get(): string
+    {
+        if (!$this->peerList || count($this->peerList) < self::MINIMUM_PEERS_REQUIRED) {
+            $this->retrieveFromPreloadList();
+        }
+
+        return $this->selectPeer();
+    }
+
+    /**
+     * Retrieve all available initial peers.
+     * @return array
+     * @throws Exception
+     */
+    public function getAll(): array
+    {
+        if (!$this->peerList || count($this->peerList) < self::MINIMUM_PEERS_REQUIRED) {
+            $this->retrieveFromPreloadList();
+        }
+
+        return $this->peerList;
+    }
+
+    /**
+     * @return string
+     */
+    private function selectPeer(): string
+    {
+        return $this->peerList[array_rand($this->peerList)];
+    }
+
+    /**
+     * Retrieve a peer from
+     *
+     * @return void
+     * @throws Exception
+     */
+    private function retrieveFromPreloadList(): void
+    {
+        $peerList = file(self::PRELOAD_LIST, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+
+        if (!$peerList || count($peerList) < self::MINIMUM_PEERS_REQUIRED) {
+            throw new Exception(self::PRELOAD_ERROR);
+        }
+
+        $this->peerList = $peerList;
+    }
+}

--- a/include/InitialPeers.php
+++ b/include/InitialPeers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Arionum;
+namespace Arionum\Node;
 
 /**
  * Class InitialPeers

--- a/include/config-sample.inc.php
+++ b/include/config-sample.inc.php
@@ -55,7 +55,35 @@ $_config['transaction_propagation_peers'] = 5;
 $_config['max_test_peers'] = 5;
 
 // The initial peers to sync from in sanity
-$_config['initial_peer_list'] = [];
+$_config['initial_peer_list'] = [
+    'http://peer1.arionum.com',
+    'http://peer2.arionum.com',
+    'http://peer3.arionum.com',
+    'http://peer4.arionum.com',
+    'http://peer5.arionum.com',
+    'http://peer6.arionum.com',
+    'http://peer7.arionum.com',
+    'http://peer8.arionum.com',
+    'http://peer9.arionum.com',
+    'http://peer10.arionum.com',
+    'http://peer11.arionum.com',
+    'http://peer12.arionum.com',
+    'http://peer13.arionum.com',
+    'http://peer14.arionum.com',
+    'http://peer15.arionum.com',
+    'http://peer16.arionum.com',
+    'http://peer17.arionum.com',
+    'http://peer18.arionum.com',
+    'http://peer19.arionum.com',
+    'http://peer20.arionum.com',
+    'http://peer21.arionum.com',
+    'http://peer22.arionum.com',
+    'http://peer23.arionum.com',
+    'http://peer24.arionum.com',
+    'http://peer25.arionum.com',
+    'http://peer26.arionum.com',
+    'http://peer27.arionum.com',
+];
 
 /*
 |--------------------------------------------------------------------------
@@ -72,7 +100,7 @@ $_config['max_mempool_rebroadcast'] = 5000;
 // The number of blocks between rebroadcasting transactions
 $_config['sanity_rebroadcast_height'] = 30;
 
-// Block accepting transfers from addresses blacklisted by the Arionum devs 
+// Block accepting transfers from addresses blacklisted by the Arionum devs
 $_config['use_official_blacklist'] = true;
 
 /*

--- a/include/config-sample.inc.php
+++ b/include/config-sample.inc.php
@@ -54,6 +54,9 @@ $_config['transaction_propagation_peers'] = 5;
 // How many new peers to check from each peer
 $_config['max_test_peers'] = 5;
 
+// The initial peers to sync from in sanity
+$_config['initial_peer_list'] = [];
+
 /*
 |--------------------------------------------------------------------------
 | Mempool Configuration

--- a/include/init.inc.php
+++ b/include/init.inc.php
@@ -13,10 +13,12 @@ if (php_sapi_name() !== 'cli' && substr_count($_SERVER['PHP_SELF'], "/") > 1) {
     die("This application should only be run in the main directory /");
 }
 
+require_once __DIR__.'/Exception.php';
 require_once("include/config.inc.php");
 require_once("include/db.inc.php");
 require_once("include/functions.inc.php");
 require_once __DIR__.'/Blacklist.php';
+require_once __DIR__.'/InitialPeers.php';
 require_once("include/block.inc.php");
 require_once("include/account.inc.php");
 require_once("include/transaction.inc.php");

--- a/sanity.php
+++ b/sanity.php
@@ -60,8 +60,8 @@ if ($arg != "microsanity") {
     sleep(3);
 }
 
-
 require_once("include/init.inc.php");
+require_once __DIR__.'/include/InitialPeers.php';
 
 if ($argv[1]=="dev") {
     error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE);
@@ -267,16 +267,20 @@ $peered = [];
 // if we have no peers, get the seed list from the official site
 if ($total_peers == 0 && $_config['testnet'] == false) {
     $i = 0;
-    echo "No peers found. Attempting to get peers from arionum.com\n";
-    $f = file("https://www.arionum.com/peers.txt");
-    shuffle($f);
-    // we can't connect to arionum.com
-    if (count($f) < 2) {
-        @unlink("tmp/sanity-lock");
-        die("Could not connect to arionum.com! Will try later!\n");
+    echo 'No peers found. Attempting to get peers from the initial list.'.PHP_EOL;
+
+    $initialPeers = new \Arionum\InitialPeers($_config['initial_peer_list'] ?? []);
+
+    try {
+        $peers = $initialPeers->getAll();
+    } catch (\Arionum\Exception $e) {
+        @unlink('tmp/sanity-lock');
+        die($e->getMessage().PHP_EOL);
     }
-    foreach ($f as $peer) {
-        //peer with all until max_peers, this will ask them to send a peering request to our peer.php where we add their peer to the db.
+
+    foreach ($peers as $peer) {
+        // Peer with all until max_peers
+        // This will ask them to send a peering request to our peer.php where we add their peer to the db.
         $peer = trim(san_host($peer));
         $bad_peers = ["127.", "localhost", "10.", "192.168.","172.16.","172.17.","172.18.","172.19.","172.20.","172.21.","172.22.","172.23.","172.24.","172.25.","172.26.","172.27.","172.28.","172.29.","172.30.","172.31."];
 

--- a/sanity.php
+++ b/sanity.php
@@ -268,11 +268,11 @@ if ($total_peers == 0 && $_config['testnet'] == false) {
     $i = 0;
     echo 'No peers found. Attempting to get peers from the initial list.'.PHP_EOL;
 
-    $initialPeers = new \Arionum\InitialPeers($_config['initial_peer_list'] ?? []);
+    $initialPeers = new \Arionum\Node\InitialPeers($_config['initial_peer_list'] ?? []);
 
     try {
         $peers = $initialPeers->getAll();
-    } catch (\Arionum\Exception $e) {
+    } catch (\Arionum\Node\Exception $e) {
         @unlink('tmp/sanity-lock');
         die($e->getMessage().PHP_EOL);
     }

--- a/sanity.php
+++ b/sanity.php
@@ -60,8 +60,7 @@ if ($arg != "microsanity") {
     sleep(3);
 }
 
-require_once("include/init.inc.php");
-require_once __DIR__.'/include/InitialPeers.php';
+require_once __DIR__.'/include/init.inc.php';
 
 if ($argv[1]=="dev") {
     error_reporting(E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE);


### PR DESCRIPTION
This adds the initial peers list to a `initial_peer_list` array in the `config.php` file.

It adds an `InitialPeers` class that is passed the peer list (from the config) and then can be used to either select a single peer, or fallback to the list on the Arionum domain.
It also adds a new `Arionum\Node\Exception` class for custom exceptions.

I have updated the code in the sanity to use this new class (see below).

https://github.com/arionum/node/blob/98dba661b1bc4b7744eecf52d558279fa0b6c5aa/sanity.php#L269-L278

----------

Testing this using a custom list results in (the error message is because it was local, so no accessible IP):

![Example usage](https://i.imgur.com/7ZO1CGV.png)

----------

_Note that all new code is PSR-2 compliant._

Closes #24