### PR TITLE
Update to use the sanity interval for the lock

### DIFF
--- a/sanity.php
+++ b/sanity.php
@@ -48,12 +48,12 @@ if (file_exists(SANITY_LOCK_PATH)) {
     $pid_time = filemtime(SANITY_LOCK_PATH);
 
     // If the process died, restart after 3 times the sanity interval
-    if (time() - $pid_time > ($_config['sanity_interval'] * 3)) {
+    if (time() - $pid_time > ($_config['sanity_interval'] ?? 900 * 3)) {
         @unlink(SANITY_LOCK_PATH);
     }
 
     if (!$ignore_lock) {
-        die("Sanity lock in place");
+        die("Sanity lock in place".PHP_EOL);
     }
 }
 


### PR DESCRIPTION
Closes #26 

This PR changes to use the `sanity_interval` value in the config (falls back to 900) for orphan lock file removal.

It will remove the file if it is older than 3 times the sanity interval.

This also adds a `SANITY_LOCK_PATH` constant which makes sure that the path is consistent.