### PR TITLE
Add public_key variable where it was undefined

### DIFF
--- a/api.php
+++ b/api.php
@@ -203,6 +203,7 @@ if ($q == "getAddress") {
      */
 
     $account = san($data['account']);
+    $public_key = san($data['public_key'] ?? '');
     if (!empty($public_key) && strlen($public_key) < 32) {
         api_err("Invalid public key");
     }


### PR DESCRIPTION
Previously the `public_key` variable is being referenced but it is never set in this API call. This allows the correct functionality to occur when the `public_key` query parameter is set.