### PR TITLE
Remove Peer 27 from the initial peer list

### DIFF
--- a/include/config-sample.inc.php
+++ b/include/config-sample.inc.php
@@ -82,7 +82,6 @@ $_config['initial_peer_list'] = [
     'http://peer24.arionum.com',
     'http://peer25.arionum.com',
     'http://peer26.arionum.com',
-    'http://peer27.arionum.com',
 ];
 
 // does not peer with any of the peers. Uses the seed peers and syncs only from those peers. Requires a cronjob on sanity.php


### PR DESCRIPTION
Peer 27 has been down for months and is causing various issues. It would be good to remove it from the `peers.txt` file as well, or restore it. But to prevent possible issues with initial node setup, it could be removed from the config.