### PR TITLE
Add Git ignore file to the tmp directory

### DIFF
--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!db-update


### PR DESCRIPTION
The sanity process generates a lot of temporary files in the tmp directory. These display as untracked changes in Git and make it a lot harder to view only actual changes to the repository.