### PR TITLE
Add Travis support for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,21 @@ dist: trusty
 language: php
 
 php:
-  - 7.2
-  - 7.3
-  - nightly
+- 7.2
+- 7.3
+- nightly
 
 matrix:
   allow_failures:
-    - php: nightly
+  - php: nightly
 
 ## Cache composer
 cache:
   directories:
-    - $HOME/.composer/cache
+  - $HOME/.composer/cache
 
 before_script:
-  - travis_retry composer update --no-interaction --prefer-dist
+- travis_retry composer update --no-interaction --prefer-dist
 
 script:
-  - vendor/bin/phpcs -l --standard=psr2 . include
+- vendor/bin/phpcs -l --standard=psr2 . include

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 
 php:
   - 7.2
+  - 7.3
   - nightly
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ matrix:
   allow_failures:
     - php: nightly
 
-# This triggers builds to run on the new TravisCI infrastructure.
-# See: https://docs.travis-ci.com/user/reference/trusty#Container-based-with-sudo%3A-false
-sudo: false
-
 ## Cache composer
 cache:
   directories:


### PR DESCRIPTION
This doesn't really affect anything for the actual node as Travis isn't used officially, and appears to work [as expected](https://travis-ci.com/pxgamer/arionum-node/builds/94838840) (yes it fails due to PSR-2 not being enforced by the developers).