### PR TITLE
Bump version number to v0.4.5

### DIFF
--- a/include/init.inc.php
+++ b/include/init.inc.php
@@ -1,6 +1,6 @@
 <?php
 // ARO version
-define("VERSION", "0.4.4");
+define("VERSION", "0.4.5");
 // Amsterdam timezone by default, should probably be moved to config
 date_default_timezone_set("UTC");
 


### PR DESCRIPTION
I've also created a signed tag for this [here](https://github.com/pxgamer/arionum-node/releases/tag/v0.4.5), feel free to pull that into the main repo.